### PR TITLE
[BUG] namespace limited actions do not honor --namespace option provided

### DIFF
--- a/replace-certificates.py
+++ b/replace-certificates.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import openshift as oc
+import openshift.context
 from base64 import b64decode, b64encode
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -393,7 +394,7 @@ if __name__ == "__main__":
         oc.use_config_context(options.context)
     if not options.all:
         logging.debug(f"using namespace {options.namespace}")
-        oc.project(options.namespace)
+        oc.set_default_project(options.namespace)
     else:
         logging.debug(f"using all namespaces")
 


### PR DESCRIPTION
openshift.project('something') isn't sufficient if not called within context so moved to `set_default_project` option.
fixes 